### PR TITLE
Update Scrapy

### DIFF
--- a/python.md
+++ b/python.md
@@ -46,7 +46,7 @@ This list contains python libraries related to web scraping and data processing
 ## Web-Scraping Frameworks
 * Full Featured Crawlers
   * [grab](http://docs.grablib.org/en/latest/#grab-spider-user-manual) - web-scraping framework (pycurl/multicurl based)
-  * [scrapy](http://scrapy.org/) - web-scraping framework (twisted based). Does not support Python3.
+  * [scrapy](http://scrapy.org/) - web-scraping framework (twisted based).
   * [pyspider](https://github.com/binux/pyspider) - A powerful spider system.
   * [cola](https://github.com/chineking/cola) - A distributed crawling framework.
 * Other


### PR DESCRIPTION
I have removed "Does not support Python3" from Scrapy hints in Web-Scraping Frameworks.
Because, latest scrapy 1.2 runs on Python 2.7 and Python 3.3 or above.
