### PR TITLE
add rq

### DIFF
--- a/python.md
+++ b/python.md
@@ -199,6 +199,7 @@ statistic of browsers
 * [threading](http://docs.python.org/2.7/library/threading.html) - standard python library to run threads. Effective for I/O-bound tasks. Useless for CPU-bound tasks because of python GIL.
 * [multiprocessing](http://docs.python.org/2.7/library/multiprocessing.html) - standard python library to run processes.
 * [celery](http://www.celeryproject.org/) - An asynchronous task queue/job queue based on distributed message passing.
+* [rq](https://python-rq.org/) - Simple job queues for Python
 * [concurrent-futures](https://docs.python.org/3/library/concurrent.futures.html) - The concurrent.futures module provides a high-level interface for asynchronously executing callables.
 
 ## Asynchronous


### PR DESCRIPTION
RQ (Redis Queue) is a simple Python library for queueing jobs and processing them in the background with workers.