### PR TITLE
Added Playwright

### DIFF
--- a/javascript.md
+++ b/javascript.md
@@ -140,6 +140,7 @@ This list contains JavaScript libraries related to web scraping and data process
 * [headless-chrome-crawler](https://github.com/yujiosaka/headless-chrome-crawler) - Distributed crawler powered by Headless Chrome
 * [puppeteer-recorder](https://github.com/checkly/puppeteer-recorder) - Puppeteer recorder is a Chrome extension that records your browser interactions and generates a Puppeteer script.
 * [wendigo](https://github.com/angrykoala/wendigo) - Test-oriented headless browser, built on top of Puppeteer.
+* [Playwright](https://github.com/microsoft/playwright) - Node.js library to automate Chromium, Firefox and WebKit with a single API
 
 ## Multiprocessing
   * [nexpect](https://github.com/nodejitsu/nexpect) - spawn and control child processes in node.js with ease


### PR DESCRIPTION
Playwright is Node.js library to automate Chromium, Firefox and WebKit with a single API