### PR TITLE
Add AmazonCaptcha to Captcha Solving Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Web scraping chats: [@grablab](https://t.me/grablab) (English) and [@grablab_ru]
 
 * [2captcha.com](https://2captcha.com/?from=3019071) - 2captcha.com
 * [anti-gate.com](http://getcaptchasolution.com/ijykrofoxz) - anti-gate.com
+* [AmazonCaptcha](https://github.com/a-maliarov/amazoncaptcha) - free Pillow-based solver for Amazon's text captcha
 
 ## Contributing
 


### PR DESCRIPTION
Hi! I haven't found any information about limitations of "Captcha Solving Services" category, and, more precisely - whether it can contain python libraries (as in "not external services").

Please, let me know, if it's not appropriate. Thank you!