### PR TITLE
Add chompjs

### DIFF
--- a/python.md
+++ b/python.md
@@ -194,7 +194,6 @@ Libraries for parsing and manipulating specific text formats.
 * [textract](https://github.com/deanmalmgren/textract) - Extract text from any document, Word, PowerPoint, PDFs, etc.
 * [messytables](https://github.com/okfn/messytables) - Tools for parsing messy tabular data
 * [rows](https://github.com/turicas/rows) - A common, beautiful interface to tabular data, no matter the format (currently CSV, HTML, XLS, TXT -- more coming!)
-* [chompjs](https://github.com/Nykakin/chompjs) - Parsing JavaScript objects into Python dictionaries
 
 ### Structured Formats : Office
 
@@ -255,6 +254,9 @@ Libraries for parsing and manipulating specific text formats.
 ### Structured Formats : Bookmarks File
 
 * [bookmarks-parser](https://github.com/bookmarks-tools/bookmarks-parser) - Parses Firefox/Chrome HTML bookmarks files
+
+### Structured Formats : JavaScript Object
+* [chompjs](https://github.com/Nykakin/chompjs) - Parsing JavaScript objects into Python dictionaries
 
 ## Serialization
 

--- a/python.md
+++ b/python.md
@@ -194,6 +194,7 @@ Libraries for parsing and manipulating specific text formats.
 * [textract](https://github.com/deanmalmgren/textract) - Extract text from any document, Word, PowerPoint, PDFs, etc.
 * [messytables](https://github.com/okfn/messytables) - Tools for parsing messy tabular data
 * [rows](https://github.com/turicas/rows) - A common, beautiful interface to tabular data, no matter the format (currently CSV, HTML, XLS, TXT -- more coming!)
+* [chompjs](https://github.com/Nykakin/chompjs) - Parsing JavaScript objects into Python dictionaries
 
 ### Structured Formats : Office
 


### PR DESCRIPTION
Adding [`chompjs`](https://github.com/Nykakin/chompjs) - a more powerful `json.loads`:
```python
>>> import chompjs
>>> import json
>>> 
>>> json.loads("{'a': 12}") # single quote
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3.9/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python3.9/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python3.9/json/decoder.py", line 353, in raw_decode
    obj, end = self.scan_once(s, idx)
json.decoder.JSONDecodeError: Expecting property name enclosed in double quotes: line 1 column 2 (char 1)
>>>
>>> chompjs.parse_js_object("{'a': 12}")
{'a': 12}

```