### PR TITLE
Added GoScrapy to the list of Web scraping frameworks in golang.

### DIFF
--- a/golang.md
+++ b/golang.md
@@ -39,6 +39,7 @@ This list contains Golang libraries related to web scraping and data processing
   * [colly](https://github.com/gocolly/colly) - Fast and elegant scraping framework
   * [dataflow kit](https://github.com/slotix/dataflowkit) - Dataflow Kit - extract structured data from web sites.
   * [flyscrape](https://github.com/philippta/flyscrape) - flyscrape is a standalone and scriptable web scraper.
+  * [goscrapy](https://github.com/tech-engine/goscrapy) - Scrapy inspired webscraping framework.
 * Other
   * [ferret](https://github.com/MontFerret/ferret) - A web scraping tool with a declarative query language.
 


### PR DESCRIPTION
Added **GoScrapy** in Web-Scraping Frameworks



**Brief:**

GoScrapy is a Scrapy-inspired web scraping framework in Golang. The primary motive is to **reduce the learning curve for developers looking to migrate from Python (Scrapy) to Golang for their web scraping projects**, while taking advantage of Golang's built-in concurrency and generally low resource requirements. Additionally, GoScrapy **aims to provide an interface similar to the popular Scrapy framework in Python**, making Scrapy developers feel at home.

**Key Features:**

- High concurrency.
- Builtin cli tool(goscrapy cli) for quick project scaffolding.
- Supports inbuilt and custom Pipelines.
- Supports inbuilt and custom Middlewares.
- Supports CSS/XPath selectors.
- Easily customizable and extendable.