### PR TITLE
add hyperbrowser to python.md and javascript.md

### DIFF
--- a/javascript.md
+++ b/javascript.md
@@ -141,6 +141,7 @@ This list contains JavaScript libraries related to web scraping and data process
 * [puppeteer-recorder](https://github.com/checkly/puppeteer-recorder) - Puppeteer recorder is a Chrome extension that records your browser interactions and generates a Puppeteer script.
 * [wendigo](https://github.com/angrykoala/wendigo) - Test-oriented headless browser, built on top of Puppeteer.
 * [Playwright](https://github.com/microsoft/playwright) - Node.js library to automate Chromium, Firefox and WebKit with a single API
+* [hyperbrowser](https://github.com/hyperbrowserai/node-sdk) - A browser automation tool that allows you to automate web browsing and web scraping tasks.
 
 ## Multiprocessing
   * [nexpect](https://github.com/nodejitsu/nexpect) - spawn and control child processes in node.js with ease

--- a/python.md
+++ b/python.md
@@ -311,6 +311,7 @@ Libraries for working with human languages.
 ### Browser Automation : Tools
 
 * [xvfbwrapper](https://github.com/cgoldberg/xvfbwrapper) - Python wrapper for running a display inside X virtual framebuffer (Xvfb)
+* [hyperbrowser](https://github.com/hyperbrowserai/python-sdk) - A browser automation tool that allows you to automate web browsing and web scraping tasks.
 
 ## Multiprocessing
 


### PR DESCRIPTION
Added hyperbrowser to python.md and javascript.md, it's a browser automation tool that can be used to automate web browsing and scraping/crawling.
Links:
- Python: https://github.com/hyperbrowserai/python-sdk
- Node: https://github.com/hyperbrowserai/node-sdk