### PR TITLE
Add Scrappe-Tout link to manuals.md

### DIFF
--- a/manuals.md
+++ b/manuals.md
@@ -91,6 +91,7 @@ Nothing yet here.
 ### URL
 
 - [WHATWG / URL](https://url.spec.whatwg.org/)
+- [Scrappe-Tout](https://github.com/isSpicyCode/scrappe-tout) - Fast HTML to Markdown scraper with Playwright. Perfect for RAG and documentation archiving.
 
 ### XMLHttpRequest
 


### PR DESCRIPTION
Ultra-fast web scraper that converts HTML to clean Markdown using Playwright. 
Features automatic content cleaning, batch URL processing, and optimized output 
for RAG systems and documentation archiving.