### PR TITLE
Add wreq to Ruby Network section

### DIFF
--- a/ruby.md
+++ b/ruby.md
@@ -41,6 +41,7 @@ This list contains ruby libraries related to web scraping and data processing
 * [Spyke](https://github.com/balvig/spyke) - Interact with REST services in an ActiveRecord-like manner.
 * [Typhoeus](https://github.com/typhoeus/typhoeus) - Typhoeus wraps libcurl in order to make fast and reliable requests.
 * [Mechanize](https://github.com/sparklemotion/mechanize) - Mechanize is a ruby library that makes automated web interaction easy.
+* [wreq](https://github.com/SearchApi/wreq-ruby) - An HTTP client with real browser TLS/HTTP2 fingerprinting, emulating Chrome, Firefox, Safari, Edge, and Opera signatures via BoringSSL.
 
 ## Web-Scraping Frameworks
 


### PR DESCRIPTION
[wreq](https://github.com/SearchApi/wreq-ruby) is the first production-ready Ruby HTTP client with real browser TLS/HTTP2 fingerprinting. It emulates exact signatures of Chrome, Firefox, Safari, Edge, Opera, and OkHttp.

Every HTTP client currently listed in the Ruby Network section — Faraday, HTTParty, HTTP, Typhoeus, Patron, RESTClient, excon — relies on either OpenSSL or libcurl compiled with OpenSSL. Even curl-based libraries like Typhoeus and Patron inherit curl's TLS stack limitations. None of them provide control over TLS extension ordering, cipher suite ordering, or HTTP/2 frame settings needed to match real browser signatures.

wreq-ruby solves this using BoringSSL (the same TLS library Chrome uses), powered by Rust via the [wreq](https://github.com/0x676e67/wreq) crate, built in collaboration with the original maintainer.

- Pre-compiled native gems for Linux (x86_64, aarch64) and macOS (arm64) — no Rust toolchain needed
- Supports the latest Ruby versions
- Used in production at [SearchApi](https://www.searchapi.io/), where we are actively investing in its development and long-term support