### PR TITLE
Add Xquik to JavaScript Web-Scraping Frameworks

### DIFF
--- a/javascript.md
+++ b/javascript.md
@@ -43,6 +43,7 @@ This list contains JavaScript libraries related to web scraping and data process
 * [Crawlee](https://github.com/apify/crawlee) - Node.js and TypeScript library that crawls with Cheerio, JSDOM, Playwright and Puppeteer while enhancing them with anti-blocking features, queue, storages and more.
 * [Ayakashi](https://github.com/ayakashi-io/ayakashi) - The next generation web scraping framework. Features all the necessary tools to create reliable and maintainable scraping and automation systems.
 * [pjscrape](https://github.com/nrabinowitz/pjscrape) - A web-scraping framework written in Javascript, using PhantomJS and jQuery
+* [Xquik](https://github.com/Xquik-dev/x-twitter-scraper) - X (Twitter) data extraction with 40+ endpoints covering tweet search, user lookup, follower extraction, engagement metrics, trending topics and webhooks.
 
 ## HTML/XML Parsing
 * General


### PR DESCRIPTION
## Summary
- Add [Xquik](https://github.com/Xquik-dev/x-twitter-scraper) to the JavaScript Web-Scraping Frameworks section
- X (Twitter) data extraction tool with 40+ endpoints — tweet search, user lookup, follower extraction, engagement metrics, trending topics & webhooks
- Open-source Node.js/TypeScript project on GitHub

## Checklist
- [x] Not a duplicate
- [x] Entry format matches existing entries: `* [name](url) - description`
- [x] Brief, one-line description
- [x] Links to GitHub repository (standalone software)