### PR TITLE
Add patchright-cli — anti-detect browser automation CLI

### DIFF
--- a/python.md
+++ b/python.md
@@ -308,7 +308,7 @@ Libraries for working with human languages.
 * [pyppeteer](https://github.com/miyakogi/pyppeteer) - Headless chrome/chromium automation library (unofficial port of puppeteer)
 * [Playwright](https://github.com/microsoft/playwright-python) - Playwright is a Python library to automate Chromium, Firefox and WebKit browsers with a single API
 * [seleniumbase](https://github.com/seleniumbase/SeleniumBase) - Python framework for Web/UI testing + RPA. 🤖 🏰 Fast, easy, and reliable.
-* [patchright-cli](https://github.com/AhaiMk01/patchright-cli) - Anti-detect browser automation CLI using Patchright (undetected Playwright fork). Bypasses Akamai, Cloudflare and other anti-bot systems.
+* [patchright-cli](https://github.com/AhaiMk01/patchright-cli) - Browser automation CLI built on Patchright (undetected Playwright fork) with enhanced site compatibility. Same command interface as playwright-cli.
 
 ### Browser Automation : Frameworks
 


### PR DESCRIPTION
## Addition

Added to **Browser Automation : Drivers** (python.md):

- **[patchright-cli](https://github.com/AhaiMk01/patchright-cli)** - Anti-detect browser automation CLI using Patchright (undetected Playwright fork). Bypasses Akamai, Cloudflare and other anti-bot systems.

## About

patchright-cli is a Python CLI tool that wraps [Patchright](https://github.com/kaliiiiiiiiii/patchright-python) with the same command interface as Microsoft's playwright-cli. It's designed for scraping anti-bot-protected sites from the command line or via AI coding agents.

Published on [PyPI](https://pypi.org/project/patchright-cli/) — install with `pip install patchright-cli`.