### PR TITLE
Add Plasmate - browser engine for AI agents

### DIFF
--- a/javascript.md
+++ b/javascript.md
@@ -182,6 +182,7 @@ This list contains JavaScript libraries related to web scraping and data process
 
 *Libraries for extracting web contents.*
 
+* [plasmate](https://github.com/plasmate-labs/plasmate) - Browser engine that outputs structured semantic content instead of raw HTML. 10-16x fewer tokens. Rust core with Python/Node/CLI interfaces.
 * [node-read](https://github.com/bndr/node-read) - Get Readable Content from any page. Based on Arc90's readability project using cheerio engine.
 * [node-ytdl-core](https://github.com/fent/node-ytdl-core) - Youtube video downloader in javascript
 * [ImageResolver](https://github.com/mauricesvay/ImageResolver) - Does its best to determine the main image on a URL without loading all images.

--- a/python.md
+++ b/python.md
@@ -76,6 +76,7 @@ This list contains python libraries related to web scraping and data processing
 
 ### Web Scraping : Tools
 
+* [plasmate](https://github.com/plasmate-labs/plasmate) - Browser engine that outputs structured semantic content instead of raw HTML. 10-16x fewer tokens. Rust core with Python/Node/CLI interfaces.
 * [portia](https://github.com/scrapinghub/portia) - Visual scraping for Scrapy.
 * [restkit](https://github.com/benoitc/restkit) - HTTP resource kit for Python. It allows you to easily access to HTTP resource and build objects around it.
 * [requests-html](https://github.com/kennethreitz/requests-html) - Pythonic HTML Parsing for Humans.


### PR DESCRIPTION
Added [plasmate](https://github.com/plasmate-labs/plasmate) to the relevant sections:

- Python: Web Scraping : Tools
- JavaScript: Web Content Extracting

Plasmate is standalone, open-source software (Rust core with Python/Node/CLI interfaces) that outputs structured semantic content instead of raw HTML.