### PR TITLE
Add crw to Rust section

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Lists of packages, services and manuals related to web scraping.
 * [Ruby](https://github.com/lorien/web-scraping/blob/master/ruby.md) - Ruby packages
 * [JavaScript](https://github.com/lorien/web-scraping/blob/master/javascript.md) - JavaScript packages
 * [Go](https://github.com/lorien/web-scraping/blob/master/golang.md) - Go packages
+* [Rust](https://github.com/lorien/web-scraping/blob/master/rust.md) - Rust packages
 * [Command Line Tools](https://github.com/lorien/web-scraping/blob/master/cli.md) - tools with a command line interface
 * [Web Scraping Manuals](https://github.com/lorien/awesome-web-scraping/blob/master/manuals.md) - list of articles and books teaching web scraping
 * [dhamaniasad / HeadlessBrowsers](https://github.com/dhamaniasad/HeadlessBrowsers) - list of (almost) all headless web browsers in existence

--- a/rust.md
+++ b/rust.md
@@ -1,0 +1,10 @@
+# Rust Web Scraping
+
+This list contains Rust libraries and tools related to web scraping and data processing
+
+* [Rust Web Scraping](#rust-web-scraping)
+   * [Web-scraping Frameworks](#web-scraping-frameworks)
+
+## Web-Scraping Frameworks
+
+* [crw](https://github.com/us/crw) - Open-source web scraper built for AI agents. Single Rust binary, built-in MCP server, Firecrawl-compatible API.


### PR DESCRIPTION
Add a new Rust section with [crw](https://github.com/us/crw) — an open-source web scraper built for AI agents. Single Rust binary, built-in MCP server, Firecrawl-compatible API.