### PR TITLE
Add cdpilot - Zero-dependency browser automation CLI

### DIFF
--- a/cli.md
+++ b/cli.md
@@ -14,6 +14,7 @@ EMPTY CONTENT
 
 ## Web Scraping
 
+* [cdpilot](https://github.com/mehmetnadir/cdpilot) - Zero-dependency browser automation CLI with 40+ commands. Uses existing browser via Chrome DevTools Protocol. Built-in MCP server for AI agents.
 * [pipet](https://github.com/bjesus/pipet) - A swiss-army tool for scraping and extracting data using selectors, JavaScript and unix pipes
 * [trafilatura](https://github.com/adbar/trafilatura) - Gather text and metadata on the Web: Crawling, scraping, extraction, output as CSV, JSON, HTML, MD, TXT, XML
 

--- a/javascript.md
+++ b/javascript.md
@@ -141,6 +141,7 @@ This list contains JavaScript libraries related to web scraping and data process
 * [puppeteer-recorder](https://github.com/checkly/puppeteer-recorder) - Puppeteer recorder is a Chrome extension that records your browser interactions and generates a Puppeteer script.
 * [wendigo](https://github.com/angrykoala/wendigo) - Test-oriented headless browser, built on top of Puppeteer.
 * [Playwright](https://github.com/microsoft/playwright) - Node.js library to automate Chromium, Firefox and WebKit with a single API
+* [cdpilot](https://github.com/mehmetnadir/cdpilot) - Zero-dependency browser automation CLI with 40+ commands. Uses existing browser via Chrome DevTools Protocol. Built-in MCP server for AI agents.
 
 ## Multiprocessing
   * [nexpect](https://github.com/nodejitsu/nexpect) - spawn and control child processes in node.js with ease


### PR DESCRIPTION
## What is cdpilot?

[cdpilot](https://github.com/mehmetnadir/cdpilot) is a zero-dependency browser automation CLI with 40+ commands. It uses your existing browser (Brave/Chrome/Chromium) via the Chrome DevTools Protocol for web scraping, content extraction, and automation.

### Key features:
- **Zero dependencies** - No npm packages or Python libraries required (stdlib only)
- **40+ commands** - Including `content` (text extraction), `html` (full HTML), `shot` (screenshots), `pdf` (PDF export), `network` (request monitoring), `cookies`, `storage`, and more
- **Built-in MCP server** - For AI agent integration
- **Uses existing browser** - No headless browser download needed, connects via CDP
- **50KB total size**

### Installation:
```
npx cdpilot launch
```

**npm:** https://www.npmjs.com/package/cdpilot
**GitHub:** https://github.com/mehmetnadir/cdpilot

Added to:
- `javascript.md` → **Browser automation and emulation** section
- `cli.md` → **Web Scraping** section