### PR TITLE
Add webclaw to Web Scraping CLI tools

### DIFF
--- a/cli.md
+++ b/cli.md
@@ -16,6 +16,7 @@ EMPTY CONTENT
 
 * [pipet](https://github.com/bjesus/pipet) - A swiss-army tool for scraping and extracting data using selectors, JavaScript and unix pipes
 * [trafilatura](https://github.com/adbar/trafilatura) - Gather text and metadata on the Web: Crawling, scraping, extraction, output as CSV, JSON, HTML, MD, TXT, XML
+* [webclaw](https://github.com/0xMassi/webclaw) - Fast web content extraction for LLMs. Rust CLI with TLS fingerprinting, markdown/JSON output, and MCP server for AI agents
 
 ## URLs
 


### PR DESCRIPTION
Adds [webclaw](https://github.com/0xMassi/webclaw) to the Web Scraping section in `cli.md`.

webclaw is a Rust CLI for fast web content extraction. It outputs clean markdown, JSON, or plain text from any URL, with TLS fingerprinting to bypass bot detection without needing a headless browser. Also includes an MCP server for AI coding assistants.

- MIT licensed, 121 GitHub stars
- `brew install 0xMassi/webclaw/webclaw` or Docker: `ghcr.io/0xmassi/webclaw`