### PR TITLE
Add safari-mcp to JavaScript browser automation

### DIFF
--- a/javascript.md
+++ b/javascript.md
@@ -139,6 +139,7 @@ This list contains JavaScript libraries related to web scraping and data process
 * [puppeteer](https://github.com/GoogleChrome/puppeteer) - Puppeteer is a Node library which provides a high-level API to control headless Chrome or Chromium over the DevTools Protocol. It can also be configured to use full (non-headless) Chrome or Chromium.
 * [headless-chrome-crawler](https://github.com/yujiosaka/headless-chrome-crawler) - Distributed crawler powered by Headless Chrome
 * [puppeteer-recorder](https://github.com/checkly/puppeteer-recorder) - Puppeteer recorder is a Chrome extension that records your browser interactions and generates a Puppeteer script.
+* [safari-mcp](https://github.com/achiya-automation/safari-mcp) - Native Safari browser automation for AI agents with 80 tools via AppleScript + JavaScript.
 * [wendigo](https://github.com/angrykoala/wendigo) - Test-oriented headless browser, built on top of Puppeteer.
 * [Playwright](https://github.com/microsoft/playwright) - Node.js library to automate Chromium, Firefox and WebKit with a single API
 


### PR DESCRIPTION
## Summary
- Adds [safari-mcp](https://github.com/achiya-automation/safari-mcp) to the "Browser automation and emulation" section in `javascript.md`
- Native Safari browser automation for AI agents — 80 tools via AppleScript + JavaScript, zero Chrome overhead
- MIT licensed, available on npm

## Checklist
- [x] Entry follows existing format (`* [name](url) - description.`)
- [x] Placed in the Browser automation and emulation section
- [x] Project is JavaScript/Node.js based