### PR TITLE
Add SnapAPI to Web Content Extracting (JavaScript)

### DIFF
--- a/javascript.md
+++ b/javascript.md
@@ -187,6 +187,7 @@ This list contains JavaScript libraries related to web scraping and data process
 * [node-ytdl-core](https://github.com/fent/node-ytdl-core) - Youtube video downloader in javascript
 * [ImageResolver](https://github.com/mauricesvay/ImageResolver) - Does its best to determine the main image on a URL without loading all images.
 
+* [SnapAPI](https://snap.michaelcli.com) - REST API for website screenshots, metadata extraction (Open Graph, Twitter Cards), PDF generation, and text extraction. Free tier available.
 ## WebSocket
 
 *Libraries for working with WebSocket.*


### PR DESCRIPTION
Adding SnapAPI to the JavaScript Web Content Extracting section.

**SnapAPI** provides:
- Website screenshots (PNG/JPEG, custom viewport)
- Metadata extraction (Open Graph, Twitter Cards, meta tags)
- PDF generation from URLs
- Text extraction from webpages

Free tier: 50 requests/month. https://snap.michaelcli.com