### PR TITLE
Add amazon-orders

### DIFF
--- a/python.md
+++ b/python.md
@@ -405,6 +405,7 @@ Tools to automate multiple actions on a website.
 * [photon](https://github.com/s0md3v/Photon) - Incredibly fast crawler designed for OSINT
 * [extractnet](https://github.com/currentsapi/extractnet) - Machine Learning based content and metadata extraction in Python 3
 * [visura-api](https://github.com/zornade/visura-api) - REST API for automated Italian cadastral property record extraction from the SISTER portal, using Playwright for browser automation with SPID authentication.
+* [amazon-orders](https://github.com/alexdlaird/amazon-orders) - A Python library (and CLI) for Amazon order history; line items, prices, and receipts.
 
 ### Web Automation : Account Creation
 


### PR DESCRIPTION
Added amazon-orders under Web Automation > Content Extraction in python.md. Standalone Python library (and CLI) for Amazon order history; line items, prices, and receipts.