### PR TITLE
add invisible_playwright (Playwright-compatible stealth Firefox)

### DIFF
--- a/python.md
+++ b/python.md
@@ -307,6 +307,7 @@ Libraries for working with human languages.
 * [Splash](https://github.com/scrapinghub/splash) - Lightweight, scriptable browser as a service with an HTTP API.
 * [pyppeteer](https://github.com/miyakogi/pyppeteer) - Headless chrome/chromium automation library (unofficial port of puppeteer)
 * [Playwright](https://github.com/microsoft/playwright-python) - Playwright is a Python library to automate Chromium, Firefox and WebKit browsers with a single API
+* [invisible_playwright](https://github.com/feder-cr/invisible_playwright) - drop-in Playwright replacement that ships a patched Firefox 150 binary with C++ source-level fingerprint patches for anti-detect automation (canvas, WebGL, audio, fonts, WebRTC, navigator, timezone, SOCKS5 auth, DevTools)
 * [seleniumbase](https://github.com/seleniumbase/SeleniumBase) - Python framework for Web/UI testing + RPA. 🤖 🏰 Fast, easy, and reliable.
 
 ### Browser Automation : Frameworks


### PR DESCRIPTION
Adds invisible_playwright in the Browser Automation : Drivers section, right after the existing Playwright entry.

What it is: a Python wrapper that ships a patched Firefox 150 binary with C++ source-level fingerprint patches across canvas, WebGL, audio, fonts, WebRTC, navigator, timezone, SOCKS5 auth and DevTools detection. Drop-in replacement for sync_playwright() - same API surface, no script rewrite needed.

Why it fits the list: it lives in the same Browser Automation : Drivers space as Playwright and seleniumbase, but is specifically aimed at anti-detect scraping where the default Firefox/Chromium binaries get fingerprinted out.

Measured detection results on Windows 10: 0.90 reCAPTCHA v3 score, 0 CreepJS lies, FingerprintJS Pro all flags negative. MIT licensed.