### PR TITLE
Add xbrowser - browser automation CLI for web scraping

### DIFF
--- a/cli.md
+++ b/cli.md
@@ -16,6 +16,7 @@ EMPTY CONTENT
 
 * [pipet](https://github.com/bjesus/pipet) - A swiss-army tool for scraping and extracting data using selectors, JavaScript and unix pipes
 * [trafilatura](https://github.com/adbar/trafilatura) - Gather text and metadata on the Web: Crawling, scraping, extraction, output as CSV, JSON, HTML, MD, TXT, XML
+* [xbrowser](https://github.com/dyyz1993/xbrowser) - Browser automation CLI with scrape, crawl, map, network commands. JS-rendered pages to Markdown, 68 plugins. [MIT]
 
 ## URLs
 

--- a/javascript.md
+++ b/javascript.md
@@ -142,6 +142,7 @@ This list contains JavaScript libraries related to web scraping and data process
 * [puppeteer-recorder](https://github.com/checkly/puppeteer-recorder) - Puppeteer recorder is a Chrome extension that records your browser interactions and generates a Puppeteer script.
 * [wendigo](https://github.com/angrykoala/wendigo) - Test-oriented headless browser, built on top of Puppeteer.
 * [Playwright](https://github.com/microsoft/playwright) - Node.js library to automate Chromium, Firefox and WebKit with a single API
+* [xbrowser](https://github.com/dyyz1993/xbrowser) - Browser automation CLI with scrape, crawl, map commands. JS-rendered pages to Markdown, robots.txt respect, 68 plugins. [MIT]
 
 ## Multiprocessing
   * [nexpect](https://github.com/nodejitsu/nexpect) - spawn and control child processes in node.js with ease


### PR DESCRIPTION
## Add xbrowser

[xbrowser](https://github.com/dyyz1993/xbrowser) is a browser automation CLI with web scraping capabilities.

### What it does

- `scrape` - Convert JS-rendered pages to clean Markdown/HTML/Text
- `crawl` - Recursive site crawler with depth control and `robots.txt` respect
- `map` - URL discovery and site structure mapping
- `network` - HTTP traffic capture and analysis
- 68 built-in plugins for major platforms (Google, Bing, Baidu, Reddit, etc.)
- Anti-bot detection scanner

### Changes

- Added xbrowser to `cli.md` (Web Scraping section)
- Added xbrowser to `javascript.md` (Browser automation and emulation section)

### Install

```bash
npm i -g @dyyz1993/xbrowser
```

Docs: https://xbrowser.dev | MIT License