### PR TITLE
Add Geonode to Proxy Server Marketplaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ List of packages, services, and manuals related to web scraping.
 
 ## Captcha Solving Services
 
+* Adding [Geonode](https://geonode.com) to the "Proxy Server Marketplaces" section, which currently lists blackhatworld and antichat forum links. Geonode is a rotating residential and datacenter proxy service with REST API access — a direct fit for the section.
 * [https://2captcha.com](https://2captcha.com/?from=3019071)
 
 ## Proxy Server Marketplaces


### PR DESCRIPTION
I run Geonode. Adding Geonode (residential + datacenter proxy network) to the **Captcha Solving Services** list.

Proposed entry:
```
Adding [Geonode](https://geonode.com) to the "Proxy Server Marketplaces" section, which currently lists blackhatworld and antichat forum links. Geonode is a rotating residential and datacenter proxy service with REST API access — a direct fit for the section.
```

Happy to adjust the wording or section if it doesn't fit the list's conventions.