### PR TITLE
Add Geonode to Proxy Server Marketplaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ List of packages, services, and manuals related to web scraping.
 
 ## Proxy Server Marketplaces
 
+* [Geonode](https://geonode.com) — Rotating residential and datacenter proxies with REST API access.
 * https://www.blackhatworld.com/forums/proxies-for-sale.112/
 * https://forum.antichat.com/forums/147/
 


### PR DESCRIPTION
I run Geonode. Adding Geonode (residential + datacenter proxy network) to the **Proxy Server Marketplaces** list.

Proposed entry:
```
- [Geonode](https://geonode.com) — Rotating residential and datacenter proxies with REST API access.
```

Happy to adjust the wording or section if it doesn't fit the list's conventions.