### PR TITLE
Add browser-cli to Web Scraping CLI tools

### DIFF
--- a/cli.md
+++ b/cli.md
@@ -16,6 +16,7 @@ EMPTY CONTENT
 
 * [pipet](https://github.com/bjesus/pipet) - A swiss-army tool for scraping and extracting data using selectors, JavaScript and unix pipes
 * [trafilatura](https://github.com/adbar/trafilatura) - Gather text and metadata on the Web: Crawling, scraping, extraction, output as CSV, JSON, HTML, MD, TXT, XML
+* [browser-cli](https://github.com/zmysysz/browser-cli) - CLI browser automation tool for AI agents with stealth mode and state persistence, powered by Playwright
 
 ## URLs
 


### PR DESCRIPTION
## Add browser-cli

Browser-CLI is a CLI browser automation tool for AI agents, powered by Playwright.

### Features
- CLI-first design for AI agents and automation scripts
- Built-in stealth mode to bypass browser automation detection
- State persistence (save/restore login sessions)
- CDP connection to external browsers

Added to the Web Scraping CLI tools list.