### PR TITLE
Add browser-cli to CLI tools

### DIFF
--- a/cli.md
+++ b/cli.md
@@ -16,7 +16,9 @@ EMPTY CONTENT
 
 * [pipet](https://github.com/bjesus/pipet) - A swiss-army tool for scraping and extracting data using selectors, JavaScript and unix pipes
 * [trafilatura](https://github.com/adbar/trafilatura) - Gather text and metadata on the Web: Crawling, scraping, extraction, output as CSV, JSON, HTML, MD, TXT, XML
+* [browser-cli](https://github.com/zmysysz/browser-cli) - CLI tool for browser automation and web scraping with stealth mode and state persistence, powered by Playwright
 
 ## URLs
 
 * [courlan](https://github.com/adbar/courlan) - Clean, filter and sample URLs to optimize data collection: Deduplication, spam, content and language filters
+


### PR DESCRIPTION
## Summary

Adds browser-cli to the Web Scraping CLI tools list.

### About browser-cli

A command-line tool for browser automation and web scraping, powered by Playwright.

**Features:**
- CLI-first design for automation scripts
- Built-in stealth mode to bypass browser automation detection
- State persistence (save/restore login sessions)
- CDP connection to external browsers
- Screenshot and PDF generation
- Form filling and page navigation

### Checklist

- [x] The tool is relevant to web scraping
- [x] The description follows the existing format
- [x] No duplicates in the list