### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ List of packages, services, and manuals related to web scraping.
 * [dhamaniasad / HeadlessBrowsers](https://github.com/dhamaniasad/HeadlessBrowsers) - list of (almost) all headless web browsers in existence
 * [DNS over HTTPS providers](https://github.com/curl/curl/wiki/DNS-over-HTTPS) - list of DNS over HTTPS providers
 * [Awesome Pastebins](https://github.com/lorien/awesome-pastebins) - list of pastebin sites
-
+* [ProxyVero](https://www.proxyvero.com) - A free live benchmark index and dynamic bandwidth cost simulator for web scraping proxies.
 ## Captcha Solving Services
 
 * [https://2captcha.com](https://2captcha.com/?from=3019071)


### PR DESCRIPTION
Hi! 

I've added ProxyVero to the Proxies/Tools section. 

It is a 100% free, non-commercial benchmarking index and pricing simulator built for backend developers and indie hackers. When scaling up dynamic headless scrapers (like Playwright), estimating metered residential proxy bandwidth costs is always a massive headache. This free simulator helps developers pre-calculate and compare theoretical proxy infrastructure budgets before running heavy concurrent workers.

The tool is fully functional, free of annoying ads, and purely aimed at supporting the open-source scraping community. Hope it makes a valuable addition to this awesome list!

Thanks for maintaining this great repository!