### PR TITLE
Add WebReaper to Web Scraping CLI tools

### DIFF
--- a/cli.md
+++ b/cli.md
@@ -16,6 +16,7 @@ EMPTY CONTENT
 
 * [pipet](https://github.com/bjesus/pipet) - A swiss-army tool for scraping and extracting data using selectors, JavaScript and unix pipes
 * [trafilatura](https://github.com/adbar/trafilatura) - Gather text and metadata on the Web: Crawling, scraping, extraction, output as CSV, JSON, HTML, MD, TXT, XML
+* [WebReaper](https://github.com/alex-on-ai/WebReaper) - AI-native single-binary web scraper CLI with bundled Claude Code skill and MCP support
 
 ## URLs
 


### PR DESCRIPTION
Adds [WebReaper](https://github.com/alex-on-ai/WebReaper) under `cli.md → Web Scraping` (alphabetical, after trafilatura).

WebReaper is an MIT-licensed, single-binary AI-native web scraper CLI (139★, actively maintained). It outputs clean markdown, ships an MCP server, and bundles a Claude Code skill. Entry format matches the surrounding list (leading `*`, no trailing period).