### PR TITLE
Add proxyspin to Proxy Server

### DIFF
--- a/python.md
+++ b/python.md
@@ -435,6 +435,7 @@ Libraries for working with WebSocket.
 ## Proxy Server
 
 * [scylla](https://github.com/imWildCat/scylla) - Intelligent proxy pool for Humans
+* [proxyspin](https://github.com/gproxynet/proxyspin) - Rotating proxy pool for Scrapy, Playwright and requests with health tracking, ban detection and sticky sessions.
 * [ProxyBroker](https://github.com/constverum/Proxybroker) - Proxy [Finder | Checker | Server]. HTTP(S) & SOCKS
 * [shadowsocks](https://github.com/shadowsocks/shadowsocks) - A fast tunnel proxy that helps you bypass firewalls (TCP & UDP support, User management API, TCP Fast Open, Workers and graceful restart, Destination IP blacklist)
 * [tproxy](https://github.com/benoitc/tproxy) - tproxy is a simple TCP routing proxy (layer 7) built on Gevent that lets you configure the routine logic in Python


### PR DESCRIPTION
Adds [proxyspin](https://github.com/gproxynet/proxyspin) to the Proxy Server section.

It's a small, actively-maintained rotating proxy pool with health tracking (failure streaks + exponential-backoff cooldown), ban detection and sticky sessions. Unlike Scrapy-only helpers, one pool serves Scrapy, Playwright and `requests`, and it ships a CLI list checker. MIT-licensed, zero required dependencies (stdlib only).

Fits alongside scylla/ProxyBroker as a proxy-pool tool for scraping.