### PR TITLE
Add docpull to web scraping tools

### DIFF
--- a/cli.md
+++ b/cli.md
@@ -16,6 +16,7 @@ EMPTY CONTENT
 
 * [pipet](https://github.com/bjesus/pipet) - A swiss-army tool for scraping and extracting data using selectors, JavaScript and unix pipes
 * [trafilatura](https://github.com/adbar/trafilatura) - Gather text and metadata on the Web: Crawling, scraping, extraction, output as CSV, JSON, HTML, MD, TXT, XML
+* [docpull](https://github.com/raintree-technology/docpull) - Public static/server-rendered web extraction CLI that writes clean Markdown, NDJSON, SQLite, and local archives.
 
 ## URLs
 

--- a/python.md
+++ b/python.md
@@ -84,6 +84,7 @@ This list contains python libraries related to web scraping and data processing
 * [Gerapy](https://github.com/Gerapy/Gerapy) - Distributed Crawler Management Framework Based on Scrapy, Scrapyd, Django and Vue.js
 * [crawler-buddy](https://github.com/rumca-js/crawler-buddy) - Crawling server, provides crawl information via JSON interface
 * [python-proxy-headers](https://github.com/proxymesh/python-proxy-headers) - extensions for popular libraries to better handle proxy headers
+* [docpull](https://github.com/raintree-technology/docpull) - Public static/server-rendered web extraction toolkit that writes clean Markdown, NDJSON, SQLite, and local archives.
 
 ### Web Scraping : Bypass Protection
 


### PR DESCRIPTION
Adds DocPull as a Python and command-line tool for public static/server-rendered web extraction. The wording focuses on standalone public web extraction, matching this repository's contribution rules. DocPull is published on PyPI and has 17k+ downloads.
