### PR TITLE
Add proxy-dns-leak-check to Proxy Server Marketplaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ List of packages, services, and manuals related to web scraping.
 
 * https://www.blackhatworld.com/forums/proxies-for-sale.112/
 * https://forum.antichat.com/forums/147/
+* [proxy-dns-leak-check](https://github.com/SotaProxy/proxy-dns-leak-check) - CLI tool to detect DNS leaks when routing traffic through proxies
 
 ## Telegram Discussion Groups
 * [@grablab](https://t.me/grablab) - talks in English


### PR DESCRIPTION
Adds a small open-source CLI tool for detecting DNS leaks when routing traffic through proxies, listed under Proxy Server Marketplaces alongside the existing forum links. The tool compares direct vs proxied DNS resolution for a given host and flags mismatches.\n\nRepo: https://github.com/SotaProxy/proxy-dns-leak-check