### PR TITLE
Add AlterLab to Python web scraping tools

### DIFF
--- a/python.md
+++ b/python.md
@@ -84,6 +84,7 @@ This list contains python libraries related to web scraping and data processing
 * [Gerapy](https://github.com/Gerapy/Gerapy) - Distributed Crawler Management Framework Based on Scrapy, Scrapyd, Django and Vue.js
 * [crawler-buddy](https://github.com/rumca-js/crawler-buddy) - Crawling server, provides crawl information via JSON interface
 * [python-proxy-headers](https://github.com/proxymesh/python-proxy-headers) - extensions for popular libraries to better handle proxy headers
+* [AlterLab](https://alterlab.io) - Web data API with automatic website compatibility, JS rendering, and challenge resolution. Supports scrape, crawl, search, map, extract, and authenticated sessions. Pay-per-request.
 
 ### Web Scraping : Bypass Protection
 


### PR DESCRIPTION
AlterLab (https://alterlab.io) is a web data API that handles the full pipeline developers actually need — not just simple HTTP fetching.

- Automatic website compatibility (JavaScript challenges, bot detection)
- JS rendering with Playwright-based browser pool
- Challenge resolution built-in
- Six modes: scrape, crawl, search, map, extract, sessions
- Pay-per-request with no subscription
- Python SDK: `pip install alterlab` — https://pypi.org/project/alterlab/
- $1 in free credits on signup

Added to the `Web Scraping : Tools` subsection. There is no `APIs` subsection in `python.md`, and entries in that list are not alphabetically ordered, so it is appended to the end of the list.

Happy to move it to a different subsection or reword the entry if you'd prefer.
