### PR TITLE
add ProxyForFree to Proxy Server section

### DIFF
--- a/python.md
+++ b/python.md
@@ -435,11 +435,11 @@ Libraries for working with WebSocket.
 
 ## Proxy Server
 
-* [ProxyForFree](https://github.com/vsmutok/ProxyForFree) - Python tool and FastAPI service to manage multiple local proxy servers routed through free OpenVPN configurations.
 * [scylla](https://github.com/imWildCat/scylla) - Intelligent proxy pool for Humans
 * [ProxyBroker](https://github.com/constverum/Proxybroker) - Proxy [Finder | Checker | Server]. HTTP(S) & SOCKS
 * [shadowsocks](https://github.com/shadowsocks/shadowsocks) - A fast tunnel proxy that helps you bypass firewalls (TCP & UDP support, User management API, TCP Fast Open, Workers and graceful restart, Destination IP blacklist)
 * [tproxy](https://github.com/benoitc/tproxy) - tproxy is a simple TCP routing proxy (layer 7) built on Gevent that lets you configure the routine logic in Python
+* [ProxyForFree](https://github.com/vsmutok/ProxyForFree) - Python tool and FastAPI service to manage multiple local proxy servers routed through free OpenVPN configurations.
 
 ## Whois
 

--- a/python.md
+++ b/python.md
@@ -435,6 +435,7 @@ Libraries for working with WebSocket.
 
 ## Proxy Server
 
+* [ProxyForFree](https://github.com/vsmutok/ProxyForFree) - Python tool and FastAPI service to manage multiple local proxy servers routed through free OpenVPN configurations.
 * [scylla](https://github.com/imWildCat/scylla) - Intelligent proxy pool for Humans
 * [ProxyBroker](https://github.com/constverum/Proxybroker) - Proxy [Finder | Checker | Server]. HTTP(S) & SOCKS
 * [shadowsocks](https://github.com/shadowsocks/shadowsocks) - A fast tunnel proxy that helps you bypass firewalls (TCP & UDP support, User management API, TCP Fast Open, Workers and graceful restart, Destination IP blacklist)


### PR DESCRIPTION
### Summary
This PR adds [`ProxyForFree`](https://github.com/vsmutok/ProxyForFree) to the **Proxy Server** section.

### About the project
`ProxyForFree` is a Python-based utility and FastAPI service that simplifies setting up multiple parallel proxy servers on Linux. It routes traffic through isolated OpenVPN tunnels (using policy routing and 3proxy), allowing users to maintain multiple exit IPs for scraping or testing without paid proxy subscriptions.

- **FastAPI Management:** REST API and CLI to start, stop, and monitor proxies.
- **Pure Routing:** Policy routing via OpenVPN and 3proxy.
- **Developer-friendly:** Managed with `uv` and Makefile.

### Checklist
- [x] Added to the correct section (`Proxy Server`).
- [x] Placed in alphabetical order.
- [x] Description is objective and adheres to guidelines.