### PR TITLE
Add @capmonstercloud/client to Browser automation

### DIFF
--- a/javascript.md
+++ b/javascript.md
@@ -142,6 +142,7 @@ This list contains JavaScript libraries related to web scraping and data process
 * [puppeteer-recorder](https://github.com/checkly/puppeteer-recorder) - Puppeteer recorder is a Chrome extension that records your browser interactions and generates a Puppeteer script.
 * [wendigo](https://github.com/angrykoala/wendigo) - Test-oriented headless browser, built on top of Puppeteer.
 * [Playwright](https://github.com/microsoft/playwright) - Node.js library to automate Chromium, Firefox and WebKit with a single API
+* [Сapmonstercloud](https://github.com/CapMonsterCloud/capmonster-nodejs-captcha-solver) - Node.js library for automating CAPTCHA solving with CapMonster Cloud API
 
 ## Multiprocessing
   * [nexpect](https://github.com/nodejitsu/nexpect) - spawn and control child processes in node.js with ease


### PR DESCRIPTION
### Summary
Add `@capmonstercloud/client` to the `Browser automation and emulation` section in `javascript.md`.

### Compliance with Contributing Rules
- Standalone Software: Open-source Node.js library for automated CAPTCHA solving.
- Repository Age: Repository is active and older than 6 months.
- Rules Match: Appended strictly to the end of the section using the `* [name](url) - description` single-line format.