### PR TITLE
Add Universal Image Downloader to tools list

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ List of packages, services, and manuals related to web scraping.
 
 * [https://2captcha.com](https://2captcha.com/?from=3019071)
 
+* [universal-image-downloader](https://github.com/hariompatel61/universal-image-downloader) - Bulk-download images into folders from Excel/CSV sheets using Selenium, with resume and rate limiting.
+
 ## Proxy Server Marketplaces
 
 * https://www.blackhatworld.com/forums/proxies-for-sale.112/


### PR DESCRIPTION
Hello! I would like to suggest adding **[Universal Google Image Bulk Downloader Pro](https://github.com/hariompatel61/universal-image-downloader)** to the awesome list.

### What is it?
A production-grade, highly configurable image scraping tool built on top of `undetected-chromedriver` to seamlessly bypass Google's strict anti-bot mechanisms and CAPTCHAs. 

### Key Features:
- **Anti-CAPTCHA Architecture**: Uses persistent profile sessions so you only ever have to solve a CAPTCHA once.
- **Two-Tier Smart Search**: Forces Google to source images from premium stock photography sites (Freepik, Unsplash, Pexels) first, then falls back to a highly filtered Google Image search to guarantee clean, high-resolution product images.
- **Bulk Processing**: Automatically parses messy 1-column or 2-column Excel/CSV sheets and queues up thousands of downloads via a multi-job JSON configuration.
- **Resume & Skip Logic**: Instantly skips already downloaded images to save bandwidth and time.

### Why it belongs here:
It serves as an excellent, ready-to-use automated solution for AI/ML dataset generation, E-commerce catalog building, and general web scraping, specifically solving the common pain point of getting blocked while scraping images in bulk.

Let me know if you need any adjustments or if I should place it under a different specific category!
