### PR TITLE
Add universal-image-downloader to python.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,6 @@ List of packages, services, and manuals related to web scraping.
 
 * [https://2captcha.com](https://2captcha.com/?from=3019071)
 
-* [universal-image-downloader](https://github.com/hariompatel61/universal-image-downloader) - Bulk-download images into folders from Excel/CSV sheets using Selenium, with resume and rate limiting.
-
 ## Proxy Server Marketplaces
 
 * https://www.blackhatworld.com/forums/proxies-for-sale.112/

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ List of packages, services, and manuals related to web scraping.
 
 * [https://2captcha.com](https://2captcha.com/?from=3019071)
 
+* [universal-image-downloader](https://github.com/hariompatel61/universal-image-downloader) - Bulk-download images into folders from Excel/CSV sheets using Selenium, with resume and rate limiting.
+
 ## Proxy Server Marketplaces
 
 * https://www.blackhatworld.com/forums/proxies-for-sale.112/

--- a/python.md
+++ b/python.md
@@ -85,6 +85,8 @@ Libraries for working with WebSocket.
 * [Gerapy](https://github.com/Gerapy/Gerapy) - Distributed Crawler Management Framework Based on Scrapy, Scrapyd, Django and Vue.js
 * [crawler-buddy](https://github.com/rumca-js/crawler-buddy) - Crawling server, provides crawl information via JSON interface
 * [python-proxy-headers](https://github.com/proxymesh/python-proxy-headers) - extensions for popular libraries to better handle proxy headers
+* [universal-image-downloader](https://github.com/hariompatel61/universal-image-downloader) - A robust, anti-CAPTCHA bulk image scraper using undetected-chromedriver.
+
 
 ### Web Scraping : Bypass Protection
 * [cloudscraper](https://github.com/venomous/cloudscraper) - A Python module to bypass Cloudflare's anti-bot page.


### PR DESCRIPTION
Hello! I am submitting a PR to add `universal-image-downloader` to `python.md`.

**What I changed/added:**
I appended a new link to the end of the appropriate list in `python.md`.

**About the software:**
Universal Google Image Bulk Downloader Pro is a standalone Python application built on top of `undetected-chromedriver` to bypass strict anti-bot mechanisms. It parses Excel/CSV files and automates bulk image downloading using a persistent profile architecture, ensuring reliable, high-volume scraping without CAPTCHA blocks.

It is completely standalone software and does not rely on remote APIs, web services, or automated agents. 

Thank you for your time reviewing this!
